### PR TITLE
Now the result can show the entire model name no matter the length

### DIFF
--- a/llm_judge/show_result.py
+++ b/llm_judge/show_result.py
@@ -15,6 +15,8 @@ JUDGEMENT_DIR_MAP = {
     "jp_bench": DATA_DIR / "jp_bench" / "model_judgment",
 }
 
+pd.set_option("display.max_colwidth", 1000)
+
 
 def display_result_single(args):
     if args.input_file is None:
@@ -47,7 +49,6 @@ def display_result_pairwise(args):
     print(f"Input file: {input_file}")
     df_all = pd.read_json(input_file, lines=True)
     print(args.model_list)
-    pd.set_option('display.max_colwidth', 1000)
     list_res = []
     # traverse df row by row
     for index, row in df_all.iterrows():

--- a/llm_judge/show_result.py
+++ b/llm_judge/show_result.py
@@ -47,7 +47,7 @@ def display_result_pairwise(args):
     print(f"Input file: {input_file}")
     df_all = pd.read_json(input_file, lines=True)
     print(args.model_list)
-
+    pd.set_option('display.max_colwidth', 1000)
     list_res = []
     # traverse df row by row
     for index, row in df_all.iterrows():


### PR DESCRIPTION

## Why are these changes needed?

Sometimes in the result the model name will be replaced with ... when the model name is too long. 
For example ('llm-jp--llm-jp-13b-instruct-lora-jaster-dolly-o...')

So I fix it.