### PR TITLE
Update the parameters of tokenizer

### DIFF
--- a/llm_judge/gen_model_answer.py
+++ b/llm_judge/gen_model_answer.py
@@ -47,7 +47,7 @@ def generate_response(
         generation_config (Optional[dict]): Generation config.
         special_token_map (Optional[dict]): Special token map used to replace special tokens.
     """
-    inputs = tokenizer(input_text, return_tensors="pt", add_special_tokens=False, return_token_type_ids=False)
+    inputs = tokenizer(input_text, return_tensors="pt", add_special_tokens=False)
     inputs = inputs.to(model.device)
 
     input_token_ids = inputs["input_ids"]

--- a/llm_judge/gen_model_answer.py
+++ b/llm_judge/gen_model_answer.py
@@ -47,7 +47,7 @@ def generate_response(
         generation_config (Optional[dict]): Generation config.
         special_token_map (Optional[dict]): Special token map used to replace special tokens.
     """
-    inputs = tokenizer(input_text, return_tensors="pt", add_special_tokens=False)
+    inputs = tokenizer(input_text, return_tensors="pt", add_special_tokens=False, return_token_type_ids=False)
     inputs = inputs.to(model.device)
 
     input_token_ids = inputs["input_ids"]

--- a/llm_judge/gen_model_answer.py
+++ b/llm_judge/gen_model_answer.py
@@ -47,7 +47,12 @@ def generate_response(
         generation_config (Optional[dict]): Generation config.
         special_token_map (Optional[dict]): Special token map used to replace special tokens.
     """
-    inputs = tokenizer(input_text, return_tensors="pt", add_special_tokens=False, return_token_type_ids=False)
+    inputs = tokenizer(
+        input_text,
+        return_tensors="pt",
+        add_special_tokens=False,
+        return_token_type_ids=False,
+    )
     inputs = inputs.to(model.device)
 
     input_token_ids = inputs["input_ids"]

--- a/llm_judge/gen_model_answer.py
+++ b/llm_judge/gen_model_answer.py
@@ -47,7 +47,7 @@ def generate_response(
         generation_config (Optional[dict]): Generation config.
         special_token_map (Optional[dict]): Special token map used to replace special tokens.
     """
-    inputs = tokenizer(input_text, return_tensors="pt", add_special_tokens=False, return_token_type_ids=false )
+    inputs = tokenizer(input_text, return_tensors="pt", add_special_tokens=False, return_token_type_ids=False )
     inputs = inputs.to(model.device)
 
     input_token_ids = inputs["input_ids"]

--- a/llm_judge/gen_model_answer.py
+++ b/llm_judge/gen_model_answer.py
@@ -47,7 +47,7 @@ def generate_response(
         generation_config (Optional[dict]): Generation config.
         special_token_map (Optional[dict]): Special token map used to replace special tokens.
     """
-    inputs = tokenizer(input_text, return_tensors="pt", add_special_tokens=False, return_token_type_ids=False )
+    inputs = tokenizer(input_text, return_tensors="pt", add_special_tokens=False, return_token_type_ids=False)
     inputs = inputs.to(model.device)
 
     input_token_ids = inputs["input_ids"]

--- a/llm_judge/gen_model_answer.py
+++ b/llm_judge/gen_model_answer.py
@@ -47,7 +47,7 @@ def generate_response(
         generation_config (Optional[dict]): Generation config.
         special_token_map (Optional[dict]): Special token map used to replace special tokens.
     """
-    inputs = tokenizer(input_text, return_tensors="pt", add_special_tokens=False)
+    inputs = tokenizer(input_text, return_tensors="pt", add_special_tokens=False, return_token_type_ids=false )
     inputs = inputs.to(model.device)
 
     input_token_ids = inputs["input_ids"]


### PR DESCRIPTION

## Why are these changes needed?

'return_token_type_ids=False' is necessary to solve the error 'ValueError: The following model_kwargs are not used by the model: ['token_type_ids'] (note: typos in the generate arguments will also show up in this list)'